### PR TITLE
inlineScriptTags escape </script> in scripts. Null check matches.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "inline-scripts",
-  "version": "1.7.1",
+  "version": "1.7.0",
   "description": "Inline <script> tags in HTML files.",
   "main": "src/index",
   "scripts": {
-    "test-inline-script-tags": "node src/cli/inlineScriptTags.js test/testInlineScriptTags/index.html index.html; cat index.html",
-    "test-inline-stylesheets": "node src/cli/inlineStylesheets.js test/testInlineStylesheets/index.html index.html; cat index.html",
-    "test-inline-images": "node src/cli/inlineImages.js test/testInlineImages/index.html index.html; cat index.html",
-    "test-inline-requires": "node src/cli/inlineRequires.js test/testInlineRequires/main.js temp.js; cat temp.js; echo '\n'; node temp.js",
-    "test-inline-requires-2": "node src/cli/inlineRequires.js test/testInlineRequires/nested/main2.js temp.js; cat temp.js; echo '\n'; node temp.js",
-    "test-inline-environment-variables": "PORT=3000 node src/cli/inlineEnvironmentVariables.js test/testInlineEnvironmentVariables/main.js temp.js; cat temp.js",
+    "test-inline-script-tags": "inline-script-tags test/testInlineScriptTags/index.html index.html; cat index.html",
+    "test-inline-stylesheets": "inline-stylesheets test/testInlineStylesheets/index.html index.html; cat index.html",
+    "test-inline-images": "inline-images test/testInlineImages/index.html index.html; cat index.html",
+    "test-inline-requires": "inline-requires test/testInlineRequires/main.js temp.js; cat temp.js; echo '\n'; node temp.js",
+    "test-inline-requires-2": "inline-requires test/testInlineRequires/nested/main2.js temp.js; cat temp.js; echo '\n'; node temp.js",
+    "test-inline-environment-variables": "PORT=3000 inline-environment-variables test/testInlineEnvironmentVariables/main.js temp.js; cat temp.js",
     "postversion": "git push && npm publish"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "inline-scripts",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Inline <script> tags in HTML files.",
   "main": "src/index",
   "scripts": {
-    "test-inline-script-tags": "inline-script-tags test/testInlineScriptTags/index.html index.html; cat index.html",
-    "test-inline-stylesheets": "inline-stylesheets test/testInlineStylesheets/index.html index.html; cat index.html",
-    "test-inline-images": "inline-images test/testInlineImages/index.html index.html; cat index.html",
-    "test-inline-requires": "inline-requires test/testInlineRequires/main.js temp.js; cat temp.js; echo '\n'; node temp.js",
-    "test-inline-requires-2": "inline-requires test/testInlineRequires/nested/main2.js temp.js; cat temp.js; echo '\n'; node temp.js",
-    "test-inline-environment-variables": "PORT=3000 inline-environment-variables test/testInlineEnvironmentVariables/main.js temp.js; cat temp.js",
+    "test-inline-script-tags": "node src/cli/inlineScriptTags.js test/testInlineScriptTags/index.html index.html; cat index.html",
+    "test-inline-stylesheets": "node src/cli/inlineStylesheets.js test/testInlineStylesheets/index.html index.html; cat index.html",
+    "test-inline-images": "node src/cli/inlineImages.js test/testInlineImages/index.html index.html; cat index.html",
+    "test-inline-requires": "node src/cli/inlineRequires.js test/testInlineRequires/main.js temp.js; cat temp.js; echo '\n'; node temp.js",
+    "test-inline-requires-2": "node src/cli/inlineRequires.js test/testInlineRequires/nested/main2.js temp.js; cat temp.js; echo '\n'; node temp.js",
+    "test-inline-environment-variables": "PORT=3000 node src/cli/inlineEnvironmentVariables.js test/testInlineEnvironmentVariables/main.js temp.js; cat temp.js",
     "postversion": "git push && npm publish"
   },
   "bin": {

--- a/src/inlineImages.js
+++ b/src/inlineImages.js
@@ -6,8 +6,10 @@ const path = require('path');
 let inlineImages = async htmlPath => {
 	const imgTagRegex = /<img (.* )?src="([\w.\-\/]+)"(.*)>/;
 	let html = await fs.readFile(htmlPath, 'utf8');
-	let imgPromises = html
-		.match(new RegExp(imgTagRegex, 'g'))
+	let matches = html.match(new RegExp(imgTagRegex, 'g'));
+	if (!matches)
+		return html;
+	let imgPromises = matches
 		.map(imgTag => imgTag.match(imgTagRegex)[2])
 		.map(relImgPath => path.resolve(path.dirname(htmlPath), relImgPath))
 		.map(imgPath => fs.readFile(imgPath));

--- a/src/inlineScriptTags.js
+++ b/src/inlineScriptTags.js
@@ -4,12 +4,11 @@ const fs = require('fs').promises;
 const path = require('path');
 
 let inlineHtmlScripts = async htmlPath => {
-	const scriptTagRegex = /<script .*src="([\w.\-\/]+)".*><\/script>/;
+	const scriptTagRegex = /<script (?:.* )?src="([\w.\-\/]+)".*><\/script>/;
 	let html = await fs.readFile(htmlPath, 'utf8');
-
 	let matches = html.match(new RegExp(scriptTagRegex, 'g'));
-	if (matches == null) return html;
-
+	if (!matches)
+		return html;
 	let scriptPromises = matches
 		.map(scriptTag => scriptTag.match(scriptTagRegex)[1])
 		.map(relScriptPath => path.resolve(path.dirname(htmlPath), relScriptPath))
@@ -17,7 +16,7 @@ let inlineHtmlScripts = async htmlPath => {
 	let i = 0;
 	return Promise.all(scriptPromises).then(scripts =>
 		html.replace(new RegExp(scriptTagRegex, 'g'), () =>
-			`<script>${scripts[i++].replace('</script>', '<\\/script>')}</script>`));
+			`<script>${scripts[i++].replace(/<\/script>/g, '<\\/script>')}</script>`));
 };
 
 module.exports = inlineHtmlScripts;

--- a/src/inlineScriptTags.js
+++ b/src/inlineScriptTags.js
@@ -17,7 +17,7 @@ let inlineHtmlScripts = async htmlPath => {
 	let i = 0;
 	return Promise.all(scriptPromises).then(scripts =>
 		html.replace(new RegExp(scriptTagRegex, 'g'), () =>
-			`<script>${scripts[i++]}</script>`));
+			`<script>${scripts[i++].replace('</script>', '<\\/script>')}</script>`));
 };
 
 module.exports = inlineHtmlScripts;

--- a/src/inlineScriptTags.js
+++ b/src/inlineScriptTags.js
@@ -7,8 +7,8 @@ let inlineHtmlScripts = async htmlPath => {
 	const scriptTagRegex = /<script .*src="([\w.\-\/]+)".*><\/script>/;
 	let html = await fs.readFile(htmlPath, 'utf8');
 
-        let matches = html.match(new RegExp(scriptTagRegex, 'g'));
-        if (matches == null) return html;
+	let matches = html.match(new RegExp(scriptTagRegex, 'g'));
+	if (matches == null) return html;
 
 	let scriptPromises = matches
 		.map(scriptTag => scriptTag.match(scriptTagRegex)[1])

--- a/src/inlineScriptTags.js
+++ b/src/inlineScriptTags.js
@@ -4,10 +4,13 @@ const fs = require('fs').promises;
 const path = require('path');
 
 let inlineHtmlScripts = async htmlPath => {
-	const scriptTagRegex = /<script src="([\w.\-\/]+)"><\/script>/;
+	const scriptTagRegex = /<script .*src="([\w.\-\/]+)".*><\/script>/;
 	let html = await fs.readFile(htmlPath, 'utf8');
-	let scriptPromises = html
-		.match(new RegExp(scriptTagRegex, 'g'))
+
+        let matches = html.match(new RegExp(scriptTagRegex, 'g'));
+        if (matches == null) return html;
+
+	let scriptPromises = matches
 		.map(scriptTag => scriptTag.match(scriptTagRegex)[1])
 		.map(relScriptPath => path.resolve(path.dirname(htmlPath), relScriptPath))
 		.map(scriptPath => fs.readFile(scriptPath, 'utf8'));

--- a/src/inlineStylesheets.js
+++ b/src/inlineStylesheets.js
@@ -6,8 +6,10 @@ const path = require('path');
 let inlineHtmlStyles = async htmlPath => {
 	const linkTagRegex = /<link (?:.* )?rel="stylesheet"(?:.* )?href="([\w.\-\/]+)".*>|<link (?:.* )?href="([\w.\-\/]+)"(?:.* )?rel="stylesheet".*>/;
 	let html = await fs.readFile(htmlPath, 'utf8');
-	let stylesheetPromises = html
-		.match(new RegExp(linkTagRegex, 'g'))
+	let matches = html.match(new RegExp(linkTagRegex, 'g'));
+	if (!matches)
+		return html;
+	let stylesheetPromises = matches
 		.map(linkTag => {
 			let m = linkTag.match(linkTagRegex);
 			return m[1] || m[2];

--- a/test/testInlineScriptTags/index.html
+++ b/test/testInlineScriptTags/index.html
@@ -4,6 +4,6 @@
 
 <p>line 2</p>
 
-<script src="nested/myNestedScript.js"></script>
+<script src="nested/myNestedScript.js" type="application/javascript"></script>
 
 <p>line 3</p>

--- a/test/testInlineScriptTags/myScript.js
+++ b/test/testInlineScriptTags/myScript.js
@@ -1,1 +1,1 @@
-console.log('hi from myScript');
+console.log('hi from myScript </script>');

--- a/test/testInlineScriptTags/myScript.js
+++ b/test/testInlineScriptTags/myScript.js
@@ -1,1 +1,1 @@
-console.log('hi from myScript </script>');
+console.log('hi from myScript </script></script>');


### PR DESCRIPTION
I encountered an issue when trying to use your library against an html file which had additional attributes in the script tags which the regex pattern wasn't expecting eg 'type'.

`<script src="nested/myNestedScript.js" type="application/javascript"></script>`

Because the script wasn't finding any matching script tags it would reject the promise with the following error.

`UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'map' of null`

I've fixed the issue in two ways; the first is to short circuit the function in the case where no scripts are found to avoid an error being thrown unnecessarily. The second fix is to expand the regex pattern to include any additional attributes.

I've also updated the package.json file test tasks to point at the actual source code to make it easier to run quick tests.

I also had an issue where if the script to be made inline contains `</script>` anywhere in the document then it prematurely closes the tags causing havok with the HTML. I've made the script automatically escape these now.

Let me know if there's any issues with this.